### PR TITLE
Make force-with-lease the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ available [on GitHub][2].
 
 <!-- Add new changes here -->
 
+### Changed
+- [#31](https://github.com/chshersh/zbg/pull/31):
+  Command `zbg push -f` now uses git's `--force-with-lease` because it's a safer default
+  (by [@kephas])
+
 ## [0.2.0] — 2023-12-17 🎄
 
 ### Added
@@ -44,6 +49,7 @@ Initial release prepared by [@chshersh].
 [@paulpatault]: https://github.com/paulpatault
 [@sloboegen]: https://github.com/sloboegen
 [@tekknoid]: https://github.com/tekknoid
+[@kephas]: https://github.com/kephas
 
 <!-- Header links -->
 

--- a/lib/cli.ml
+++ b/lib/cli.ml
@@ -45,7 +45,7 @@ let cmd_new =
 let cmd_push =
   Command.basic ~summary:"Push the current branch to origin"
     (let%map_open.Command force =
-       flag "f" ~aliases:[ "--force" ] no_arg
+       flag "f" ~aliases:[ "--force-with-lease" ] no_arg
          ~doc:"Push forcefully and override changes"
      in
      fun () -> Git.push (to_force_flag force))

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -110,7 +110,7 @@ let push force =
   let flag_option =
     match force with
     | NoForce -> ""
-    | Force -> "--force"
+    | Force -> "--force-with-lease"
   in
   Process.proc
   @@ Printf.sprintf "git push --set-upstream origin %s %s" current_branch


### PR DESCRIPTION
If you don't mind diverging from git on this, it might be safer for users to have `zbg push -f` use `--force-with-lease`.