### PR TITLE
feat: set the HOME environment variable before invoking a command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ available [on GitHub][2].
 ## [Unreleased]
 
 <!-- Add new changes here -->
+### Fixed
+
+- [#26](https://github.com/chshersh/zbg/issues/26):
+  Set the `HOME` environment variable before calling external commands.
+  (by [@etorreborre])
 
 ## [0.2.0] — 2023-12-17 🎄
 

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -19,11 +19,7 @@ let branch_or_main (branch_opt : string option) : string =
 
 (* Read user login from user.login in git config. *)
 let get_login () : string option =
-  let home_dir = Unix.getenv "HOME" in
-  let login =
-    Process.proc_stdout
-    @@ Printf.sprintf "HOME=%s git config user.login" home_dir
-  in
+  let login = Process.proc_stdout "git config user.login" in
   if String.is_empty login then None else Some login
 
 let mk_branch_description (description : string list) : string =

--- a/lib/process.ml
+++ b/lib/process.ml
@@ -1,5 +1,9 @@
+let mk_home_cmd cmd =
+  let home_dir = Unix.getenv "HOME" in
+  Printf.sprintf "HOME=%s %s" home_dir cmd
+
 let proc_silent cmd =
-  let _exit_code = Unix.system cmd in
+  let _exit_code = Unix.system (mk_home_cmd cmd) in
   ()
 
 let proc cmd =
@@ -16,7 +20,7 @@ let collect_chan (channel : in_channel) : string =
 
 let proc_stdout cmd =
   let ((proc_stdout, _proc_stdin, _proc_stderr) as process) =
-    Unix.open_process_full cmd [||]
+    Unix.open_process_full (mk_home_cmd cmd) [||]
   in
   let stdout_result = collect_chan proc_stdout in
   let _ = Unix.close_process_full process in


### PR DESCRIPTION
This should solve #26 where the global `.gitignore` file cannot be found.