### PR TITLE
#10 Use pure function instead of calling 'basename'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ available [on GitHub][2].
   (by [@kephas])
 -[#10](https://github.com/chshersh/zbg/issues/10):
   Changed `fetch_main_branch` to get the base name using `Core.Filename.basename` rather than reading the output of the `basename` command.
-  (by [@LeedsJohn])
+  (by [@leedsjohn])
 
 ## [0.2.0] — 2023-12-17 🎄
 
@@ -54,6 +54,7 @@ Initial release prepared by [@chshersh].
 <!-- Contributors -->
 
 [@chshersh]: https://github.com/chshersh
+[@leedsjohn]: https://github.com/leedsjohn
 [@paulpatault]: https://github.com/paulpatault
 [@sloboegen]: https://github.com/sloboegen
 [@tekknoid]: https://github.com/tekknoid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ available [on GitHub][2].
 - [#31](https://github.com/chshersh/zbg/pull/31):
   Command `zbg push -f` now uses git's `--force-with-lease` because it's a safer default
   (by [@kephas])
+-[#10](https://github.com/chshersh/zbg/issues/10):
+  Changed `fetch_main_branch` to get the base name using `Core.Filename.basename` rather than reading the output of the `basename` command.
+  (by [@LeedsJohn])
 
 ## [0.2.0] — 2023-12-17 🎄
 

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -9,8 +9,7 @@ let fetch_main_branch () : string =
   let remote_main_branch =
     Process.proc_stdout "git rev-parse --abbrev-ref origin/HEAD"
   in
-  Process.proc_stdout @@ Printf.sprintf "basename %s" remote_main_branch
-(* TODO: use pure function *)
+  Core.Filename.basename remote_main_branch
 
 let branch_or_main (branch_opt : string option) : string =
   match branch_opt with


### PR DESCRIPTION
Hi, this PR responds to issue [#10](https://github.com/chshersh/zbg/issues/10).  By the recommendation of @anuragsoni, I switched the `fetch_main_branch` function to use `Core.Filename.basename` rather than calling the `basename` command.

In the issue, you suggested to move stripping via `basename` into a separate function and to write tests but I did not do this because I think the functions in Core can be trusted.

Let me know if there's any changes you would like me to make.  Thanks!