### PR TITLE
[#16] Colour staged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ available [on GitHub][2].
 - [#31](https://github.com/chshersh/zbg/pull/31):
   Command `zbg push -f` now uses git's `--force-with-lease` because it's a safer default
   (by [@kephas])
+- [#16](https://github.com/chshersh/zbg/issues/16):
+  `zbg status` now highlights staged files by making the file name bold and green.
+  (by [@leedsjohn])
 
 ## [0.2.0] — 2023-12-17 🎄
 


### PR DESCRIPTION
Hi - this PR addresses [issue 16 - Colour staged files in 'zbg status'](https://github.com/chshersh/zbg/issues/16).

I created a function to get a list of staged files using `git diff --name-only --cached [commit]`.  This is used so that I could get a list of staged files before calling `with_deleted_files` and `with_untracked_files` (which temporarily stage deleted and untracked files).  Then, we can pass the list of staged files along to `fmt_diff_stats` so we know which files we want to change to be green and bold.

There is still a loss of information in this implementation compared to calling `git status` - if a file is staged and then modified again, `zbg status` will now highlight the name green but `git status` would list the file as both staged and modified.  Do you have any thoughts about this discrepancy?

Here's an example of the current behavior:

![image](https://github.com/chshersh/zbg/assets/94880155/d400c09d-fb04-4b20-89e4-884572914a48)

Let me know what changes you would like for me to make - I'm happy to rewrite if you think this problem should be solved differently.  Thanks!