### PR TITLE
v0.3.0: Latest OCaml support + Minor UX improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - 5.0.0
+          - 5.3.0
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -33,38 +33,32 @@ jobs:
 
       - run: opam exec -- dune runtest
 
-      - name: Upload the build artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}-${{ matrix.ocaml-version }}-world.exe
-          path: _build/default/world.exe
-
   lint-doc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
-      - name: Use OCaml 5.0.0
-        uses: ocaml/setup-ocaml@v2
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@3
         with:
-          ocaml-compiler: 5.0.0
+          ocaml-compiler: 5.3.0
           dune-cache: true
 
       - name: Lint doc
-        uses: ocaml/setup-ocaml/lint-doc@v2
+        uses: ocaml/setup-ocaml/lint-doc@v3
 
   lint-fmt:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
-      - name: Use OCaml 5.0.0
-        uses: ocaml/setup-ocaml@v2
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5.0.0
+          ocaml-compiler: 5.3.0
           dune-cache: true
 
       - name: Lint fmt
-        uses: ocaml/setup-ocaml/lint-fmt@v2
+        uses: ocaml/setup-ocaml/lint-fmt@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@3
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.3.0
           dune-cache: true

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.26.1
+version = 0.27.0
 profile = default
 break-cases = fit-or-vertical
 break-infix = wrap-or-vertical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ available [on GitHub][2].
 ## [Unreleased]
 
 <!-- Add new changes here -->
+
+## [0.3.0] - 2025-08-24 🧙‍♂️💀
+
 ### Fixed
 
 - [#26](https://github.com/chshersh/zbg/issues/26):
@@ -16,15 +19,18 @@ available [on GitHub][2].
   (by [@etorreborre])
 
 ### Changed
+
 - [#31](https://github.com/chshersh/zbg/pull/31):
   Command `zbg push -f` now uses git's `--force-with-lease` because it's a safer default
   (by [@kephas])
--[#10](https://github.com/chshersh/zbg/issues/10):
+- [#10](https://github.com/chshersh/zbg/issues/10):
   Changed `fetch_main_branch` to get the base name using `Core.Filename.basename` rather than reading the output of the `basename` command.
   (by [@leedsjohn])
 - [#16](https://github.com/chshersh/zbg/issues/16):
   `zbg status` now highlights staged files by making the file name bold and green.
   (by [@leedsjohn])
+- Use `--delete --force` in `zbg done` instead of just `--delete`.
+  (by [@chshersh])
 
 ## [0.2.0] — 2023-12-17 🎄
 
@@ -70,6 +76,7 @@ Initial release prepared by [@chshersh].
 
 <!-- Versions -->
 
-[Unreleased]: https://github.com/chshersh/zbg/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/chshersh/zbg/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/chshersh/zbg/releases/tag/v0.3.0
 [0.2.0]: https://github.com/chshersh/zbg/releases/tag/v0.2.0
 [0.1.0]: https://github.com/chshersh/zbg/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ explanations.
 | ----- | ----- |
 | `zbg clear` | `git add .` <br /> `git reset --hard` |
 | `zbg commit My description` | `git add .` <br /> `git commit --message="My description"` |
-| `zbg done` | `git checkout main` <br /> `git branch -d <branch we're switching from>` |
+| `zbg done` | `git switch main` <br /> `git branch --delete --force <branch we're switching from>` |
 | `zbg log` | `git log <long custom formatting string>` |
-| `zbg new Branch name` | `git checkout -b my-github-username/Branch-name` |
+| `zbg new Branch name` | `git switch --create my-github-username/Branch-name` |
 | `zbg push` | `git push --set-upstream origin <current-branch>` |
 | `zbg rebase` | `git fetch origin main` <br /> `git rebase origin/main` |
 | `zbg stash` | `git stash push --include-untracked` |
 | `zbg status` | `git status` (but `zbg` is prettier) |
-| `zbg switch` | `git checkout main` <br /> `git pull --ff-only --prune` |
+| `zbg switch` | `git switch main` <br /> `git pull --ff-only --prune` |
 | `zbg sync` | `git pull --ff-only origin <current-branch>` |
 | `zbg sync -f` | `git fetch origin <current-branch>` <br /> `git reset --hard origin/<current-branch>` |
 | `zbg tag v0.1.0` | `git tag --annotate %s --message='Tag for the v0.1.0 release'` <br /> `git push origin --tags` |

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -84,7 +84,7 @@ let log commit =
 
 let new_ description =
   let create_branch branch_name =
-    Process.proc @@ Printf.sprintf "git checkout -b %s" branch_name
+    Process.proc @@ Printf.sprintf "git switch --create %s" branch_name
   in
   let branch_description = mk_branch_description description in
   let branch_name =
@@ -128,7 +128,7 @@ let status = Status.status
 
 let switch branch_opt =
   let branch = branch_or_main branch_opt in
-  Process.proc @@ Printf.sprintf "git checkout %s" branch;
+  Process.proc @@ Printf.sprintf "git switch %s" branch;
   Process.proc "git pull --ff-only --prune"
 
 let sync force =

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -165,4 +165,4 @@ let done_ () =
   let main_branch = fetch_main_branch () in
   switch (Some main_branch);
   if String.( <> ) prev_branch main_branch then
-    Process.proc @@ Printf.sprintf "git branch --delete %s" prev_branch
+    Process.proc @@ Printf.sprintf "git branch --delete --force %s" prev_branch

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -1,1 +1,1 @@
-let main () = Command_unix.run ~version:"0.2.0" ~build_info:"RWO" Cli.command
+let main () = Command_unix.run ~version:"0.3.0" ~build_info:"RWO" Cli.command

--- a/lib/process.mli
+++ b/lib/process.mli
@@ -1,11 +1,9 @@
 val proc : string -> unit
 (** Run a given string as an external process with arguments.
 
-Redirect the called process stdout and stderr to the current process stdout.
+    Redirect the called process stdout and stderr to the current process stdout.
 
-Also print the command with a pretty prompt.
-
-*)
+    Also print the command with a pretty prompt. *)
 
 val proc_silent : string -> unit
 (** Like [proc] but doesn't print the specified command. *)
@@ -13,7 +11,6 @@ val proc_silent : string -> unit
 val proc_stdout : string -> string
 (** Run a given string as an external process with arguments.
 
-Return the process stdout as the result.
+    Return the process stdout as the result.
 
-Don't print the process output.
-*)
+    Don't print the process output. *)


### PR DESCRIPTION
This PR updates `zbg` after many months in maintenance mode. The tool was working great so far but I miss a couple of minor features.

Notable changes:

- Uses `--delete --force` for `zbg done`
- Uses `switch` instead of `checkout`
- Updates CI to use OCaml 5.3.0
- Updates changelog

Closes #29 